### PR TITLE
Support `SELECT` with empty target list

### DIFF
--- a/src/sad_spirit/pg_builder/Parser.php
+++ b/src/sad_spirit/pg_builder/Parser.php
@@ -1295,7 +1295,24 @@ class Parser
             }
         }
 
-        $stmt = new Select($this->TargetList(), $distinctClause);
+        if (
+            $distinctClause === false
+            && (
+                $this->stream->matchesKeyword([
+                    'into', 'from', 'where', 'group', 'having', 'window',
+                    'union', 'intersect', 'except',
+                    'order', 'limit', 'offset', 'fetch', 'for'
+                ])
+                || $this->stream->matchesSpecialChar(')')
+                || $this->stream->isEOF()
+            )
+        ) {
+            $targetList = new nodes\lists\TargetList([]);
+        } else {
+            $targetList = $this->TargetList();
+        }
+
+        $stmt = new Select($targetList, $distinctClause);
 
         if ($this->stream->matchesKeyword('into')) {
             throw new exceptions\NotImplementedException("SELECT INTO clauses are not supported");


### PR DESCRIPTION
Fix #13 